### PR TITLE
Add `"type": "module"` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "svelte-typed-component",
   "version": "1.1.2",
   "description": "Simplify Typescript Support for Svelte Apps",
+  "type": "module",
   "main": "index.js",
   "publishConfig": { "registry": "https://npmjs.com/" },
   "scripts": {


### PR DESCRIPTION
This will silence a warning in Vite / SvelteKit that it's generating because it can't figure out if the package is ESM or CJS